### PR TITLE
TECH-84: [wp-conditional-blocks] Basic Conditions

### DIFF
--- a/blocks/condition/block.json
+++ b/blocks/condition/block.json
@@ -14,19 +14,6 @@
   "attributes": {
     "condition": {
       "type": "string"
-    },
-    "custom": {
-      "type": "string"
-    },
-    "post": {
-      "type": "string"
-    },
-    "query": {
-      "type": "string"
-    },
-    "index": {
-      "type": "object",
-      "default": { "": "" }
     }
   }
 }

--- a/blocks/condition/edit.tsx
+++ b/blocks/condition/edit.tsx
@@ -72,7 +72,7 @@ export default function Edit({
           <PanelRow>
             {/* @ts-ignore-next-line */}
             <SelectControl
-              label={__('Conditionals', 'wp-conditional-blocks')}
+              label={__('Conditions', 'wp-conditional-blocks')}
               help={__('Select condition, e.g. "Is Home" or "Is Archive"', 'wp-conditional-blocks')}
               onChange={(next) => setAttributes({ condition: next })}
               multiple={false}

--- a/blocks/condition/edit.tsx
+++ b/blocks/condition/edit.tsx
@@ -43,10 +43,9 @@ export default function Edit({
     apiFetch({ path: '/conditional-blocks/v1/get-conditions/' })
       .then((response: any) => {
         if (Array.isArray(response.message) && response.message.length > 0) {
-          /* @ts-ignore-next-line */
-          const nextConditions = response.message.map((condition: Condition) => ({
-            value: condition.slug ?? '',
-            label: condition.name ?? '',
+          const nextConditions = response.message.map((blockCondition: Condition) => ({
+            value: blockCondition.slug ?? '',
+            label: blockCondition.name ?? '',
           }));
           setConditions(nextConditions);
         } else {

--- a/blocks/condition/edit.tsx
+++ b/blocks/condition/edit.tsx
@@ -43,7 +43,8 @@ export default function Edit({
     apiFetch({ path: '/conditional-blocks/v1/get-conditions/' })
       .then((response: any) => {
         if (Array.isArray(response.message) && response.message.length > 0) {
-          const nextConditions = response.message.map((condition) => ({
+          /* @ts-ignore-next-line */
+          const nextConditions = response.message.map((condition: Condition) => ({
             value: condition.slug ?? '',
             label: condition.name ?? '',
           }));

--- a/blocks/condition/edit.tsx
+++ b/blocks/condition/edit.tsx
@@ -20,7 +20,7 @@ interface Conditions {
 }
 
 // Structure coming from Conditions API.
-interface Condition {
+interface BlockCondition {
   slug: string;
   name: string;
 }
@@ -43,7 +43,7 @@ export default function Edit({
     apiFetch({ path: '/conditional-blocks/v1/get-conditions/' })
       .then((response: any) => {
         if (Array.isArray(response.message) && response.message.length > 0) {
-          const nextConditions = response.message.map((blockCondition: Condition) => ({
+          const nextConditions = response.message.map((blockCondition: BlockCondition) => ({
             value: blockCondition.slug ?? '',
             label: blockCondition.name ?? '',
           }));

--- a/blocks/condition/edit.tsx
+++ b/blocks/condition/edit.tsx
@@ -41,8 +41,7 @@ export default function Edit({
   // Fetch and set the Conditions data.
   useEffect(() => {
     apiFetch({path: '/conditional-blocks/v1/get-conditions/'})
-      .then((response) => {
-        // @ts-ignore
+      .then((response: any) => {
         if (Array.isArray(response.message) && response.message.length > 0) {
           const nextConditions = response.message.map((condition: Condition) => ({
             value: condition.slug ?? '',

--- a/blocks/condition/edit.tsx
+++ b/blocks/condition/edit.tsx
@@ -1,21 +1,21 @@
 import { __ } from '@wordpress/i18n';
+import apiFetch from '@wordpress/api-fetch';
+import { useEffect, useState } from '@wordpress/element';
 import { InnerBlocks, InspectorControls, useBlockProps } from '@wordpress/block-editor';
 import {
-  PanelBody, PanelRow, SelectControl, TextControl,
+  PanelBody, PanelRow, SelectControl,
 } from '@wordpress/components';
-
-import { useParentBlock } from '@alleyinteractive/block-editor-tools';
 
 interface EditProps {
   attributes: {
     condition?: string;
-    custom?: string;
-    post?: string;
-    query?: string;
-    index?: object;
   };
   setAttributes: (attributes: any) => void;
-  clientId: string;
+}
+
+interface Conditions {
+  value: string;
+  label: string;
 }
 
 /**
@@ -26,16 +26,27 @@ interface EditProps {
 export default function Edit({
   attributes: {
     condition = '',
-    custom = '',
-    post = '',
-    query = '',
-    index = { '': '' },
   },
   setAttributes,
-  clientId,
 }: EditProps) {
-  const { name: parentBlock } = useParentBlock(clientId) as { name?: string } || {};
-  const [operator, compared] = Object.entries(index)[0];
+  const [conditions, setConditions] = useState<Conditions[]>([]);
+
+  // Fetch and set the Conditions data.
+  useEffect(() => {
+    apiFetch({ path: '/conditional-blocks/v1/get-conditions/' })
+      .then((response) => {
+      if (response.message.length > 0) {
+        const nextConditions = response.message.map((condition) => ({
+          value: condition.slug ?? '',
+          label: condition.name ?? '',
+        }));
+        setConditions(nextConditions);
+      } else {
+        console.error('[wp-block-conditions] Failed to retrieve conditions.');
+      }
+    }
+    );
+  }, []);
 
   return (
     <>
@@ -48,90 +59,22 @@ export default function Edit({
       <InspectorControls>
         {/* @ts-ignore-next-line */}
         <PanelBody
-          title={__('Condition', 'wp-conditional-blocks')}
+          title={__('Conditions', 'wp-conditional-blocks')}
           initialOpen
         >
           {/* @ts-ignore-next-line */}
           <PanelRow>
             {/* @ts-ignore-next-line */}
-            <TextControl
-              label={__('Query', 'wp-conditional-blocks')}
-              help={__('Query condition, ie "is_home" or "is_category"', 'wp-conditional-blocks')}
-              onChange={(next) => setAttributes({ query: next })}
-              value={query}
-            />
-          </PanelRow>
-          {/* @ts-ignore-next-line */}
-          <PanelRow>
-            {/* @ts-ignore-next-line */}
-            <TextControl
-              label={__('Post', 'wp-conditional-blocks')}
-              help={__('Post condition, ie "is_content"', 'wp-conditional-blocks')}
-              onChange={(next) => setAttributes({ post: next })}
-              value={post}
-            />
-          </PanelRow>
-
-          {/* @ts-ignore-next-line */}
-          <PanelRow>
-            {/* @ts-ignore-next-line */}
-            <TextControl
-              label={__('Custom', 'wp-conditional-blocks')}
-              help={__('Custom condition, ie "is_column"', 'wp-conditional-blocks')}
-              onChange={(next) => setAttributes({ custom: next })}
-              value={custom}
-            />
-          </PanelRow>
-
-          {/* @ts-ignore-next-line */}
-          <PanelRow>
-            {/* @ts-ignore-next-line */}
-            <TextControl
-              label={__('Condition', 'wp-conditional-blocks')}
-              help={__('Any other condition', 'wp-conditional-blocks')}
+            <SelectControl
+              label={__('Conditionals', 'wp-conditional-blocks')}
+              help={__('Select condition, e.g. "Is Home" or "Is Archive"', 'wp-conditional-blocks')}
               onChange={(next) => setAttributes({ condition: next })}
+              multiple={false}
               value={condition}
+              options={conditions}
             />
           </PanelRow>
         </PanelBody>
-
-        { parentBlock === 'wp-conditional-blocks/query' ? (
-          /* @ts-ignore-next-line */
-          <PanelBody
-            title={__('Index Condition', 'wp-conditional-blocks')}
-          >
-            <p>{__('Checks the index of how many times the parent condition block has been rendered, ie "Equal to 0", "Greater than 5"', 'wp-conditional-blocks')}</p>
-
-            {/* @ts-ignore-next-line */}
-            <PanelRow>
-              <SelectControl
-                label={__('Index Operator', 'wp-conditional-blocks')}
-                value={operator}
-                options={[
-                  { value: '', label: __('Select Operator', 'wp-conditional-blocks') },
-                  { value: '===', label: __('Equal', 'wp-conditional-blocks') },
-                  { value: '!==', label: __('Not equal', 'wp-conditional-blocks') },
-                  { value: '>', label: __('Greater than', 'wp-conditional-blocks') },
-                  { value: '<', label: __('Less than', 'wp-conditional-blocks') },
-                  { value: '>=', label: __('Greater than or equal to', 'wp-conditional-blocks') },
-                  { value: '<=', label: __('Less than or equal to', 'wp-conditional-blocks') },
-                ]}
-                onChange={(next: string) => setAttributes({ index: { [next]: compared } })}
-              />
-            </PanelRow>
-
-            {/* @ts-ignore-next-line */}
-            <PanelRow>
-              {/* @ts-ignore-next-line */}
-              <TextControl
-                label={__('Index compared', 'wp-conditional-blocks')}
-                onChange={(next) => setAttributes({ index: { [operator]: next } })}
-                type="number"
-                value={compared}
-              />
-            </PanelRow>
-          </PanelBody>
-        ) : null}
       </InspectorControls>
     </>
   );

--- a/blocks/condition/edit.tsx
+++ b/blocks/condition/edit.tsx
@@ -13,9 +13,16 @@ interface EditProps {
   setAttributes: (attributes: any) => void;
 }
 
+// Structure for the SelectControl options.
 interface Conditions {
   value: string;
   label: string;
+}
+
+// Structure coming from Conditions API.
+interface Condition {
+  slug: string;
+  name: string;
 }
 
 /**
@@ -37,7 +44,7 @@ export default function Edit({
       .then((response) => {
         // @ts-ignore
         if (Array.isArray(response.message) && response.message.length > 0) {
-          const nextConditions = response.message.map((condition) => ({
+          const nextConditions = response.message.map((condition: Condition) => ({
             value: condition.slug ?? '',
             label: condition.name ?? '',
           }));

--- a/blocks/condition/edit.tsx
+++ b/blocks/condition/edit.tsx
@@ -33,19 +33,19 @@ export default function Edit({
 
   // Fetch and set the Conditions data.
   useEffect(() => {
-    apiFetch({ path: '/conditional-blocks/v1/get-conditions/' })
+    apiFetch({path: '/conditional-blocks/v1/get-conditions/'})
       .then((response) => {
-      if (response.message.length > 0) {
-        const nextConditions = response.message.map((condition) => ({
-          value: condition.slug ?? '',
-          label: condition.name ?? '',
-        }));
-        setConditions(nextConditions);
-      } else {
-        console.error('[wp-block-conditions] Failed to retrieve conditions.');
-      }
-    }
-    );
+        // @ts-ignore
+        if (Array.isArray(response.message) && response.message.length > 0) {
+          const nextConditions = response.message.map((condition) => ({
+            value: condition.slug ?? '',
+            label: condition.name ?? '',
+          }));
+          setConditions(nextConditions);
+        } else {
+          console.error('[wp-block-conditions] Failed to retrieve conditions.');
+        }
+      });
   }, []);
 
   return (

--- a/blocks/condition/edit.tsx
+++ b/blocks/condition/edit.tsx
@@ -40,10 +40,10 @@ export default function Edit({
 
   // Fetch and set the Conditions data.
   useEffect(() => {
-    apiFetch({path: '/conditional-blocks/v1/get-conditions/'})
+    apiFetch({ path: '/conditional-blocks/v1/get-conditions/' })
       .then((response: any) => {
         if (Array.isArray(response.message) && response.message.length > 0) {
-          const nextConditions = response.message.map((condition: Condition) => ({
+          const nextConditions = response.message.map((condition) => ({
             value: condition.slug ?? '',
             label: condition.name ?? '',
           }));

--- a/blocks/condition/index.php
+++ b/blocks/condition/index.php
@@ -10,7 +10,7 @@
 
 use Alley\WP\WP_Conditional_Blocks\Global_Post_Query;
 use Alley\WP\WP_Conditional_Blocks\Validator\Slug_Is_In_Category;
-use \Alley\WP\WP_Conditional_Blocks\Conditions;
+use Alley\WP\WP_Conditional_Blocks\Conditions;
 
 /**
  * Registers the block using the metadata loaded from the `block.json` file.
@@ -54,7 +54,7 @@ function wp_conditional_blocks_condition_block_result( array $parsed_block, arra
 	// Validate callable function.
 	if (
 		empty( $wp_block_condition['callable'] )
-		|| ! is_callable( $wp_block_condition['callable'] )
+		|| false === is_callable( $wp_block_condition['callable'] )
 		|| ! $wp_query instanceof WP_Query
 	) {
 		return false;
@@ -63,7 +63,7 @@ function wp_conditional_blocks_condition_block_result( array $parsed_block, arra
 	// Execute conditional's callable.
 	$callable_result = call_user_func( $wp_block_condition['callable'] );
 
-	 /**
+	/**
 	 * Filters the condition block's result for the given condition.
 	 *
 	 * @param bool     $result   Condition result.

--- a/blocks/condition/index.php
+++ b/blocks/condition/index.php
@@ -54,7 +54,6 @@ function wp_conditional_blocks_condition_block_result( array $parsed_block, arra
 	// Validate callable function.
 	if (
 		empty( $wp_block_condition['callable'] )
-		|| false === is_callable( $wp_block_condition['callable'] )
 		|| ! $wp_query instanceof WP_Query
 	) {
 		return false;

--- a/blocks/condition/index.php
+++ b/blocks/condition/index.php
@@ -10,6 +10,7 @@
 
 use Alley\WP\WP_Conditional_Blocks\Global_Post_Query;
 use Alley\WP\WP_Conditional_Blocks\Validator\Slug_Is_In_Category;
+use \Alley\WP\WP_Conditional_Blocks\Conditions;
 
 /**
  * Registers the block using the metadata loaded from the `block.json` file.
@@ -34,11 +35,7 @@ add_action( 'init', 'wp_conditional_blocks_condition_block_init' );
  *
  * @param array{
  *   attrs?: array{
- *      query?: string|array<string|callable>,
- *      post?: mixed[],
- *      custom?: mixed[],
- *      condition?: string[],
- *      index?: array<string, int>
+ *      condition?: string,
  *   }
  * } $parsed_block Parsed condition block.
  * @param array{'postId'?: int} $context Available context.
@@ -47,154 +44,31 @@ add_action( 'init', 'wp_conditional_blocks_condition_block_init' );
 function wp_conditional_blocks_condition_block_result( array $parsed_block, array $context ): bool {
 	global $wp_query;
 
-	$num_conditions = 0;
-	$num_true       = 0;
+	$condition_slug = '';
 
-	$conditions = [];
-
-	if ( isset( $parsed_block['attrs'] ) ) {
-		$conditions = $parsed_block['attrs'];
+	if ( isset( $parsed_block['attrs']['condition'] ) ) {
+		$condition_slug = $parsed_block['attrs']['condition'];
 	}
 
-	if ( isset( $conditions['query'] ) && $wp_query instanceof WP_Query ) {
-		// Map `{"query": "is_home"} to {"query": {"is_home": true}}`.
-		if ( is_string( $conditions['query'] ) ) {
-			$conditions['query'] = array_fill_keys( (array) $conditions['query'], true );
-		}
-
-		foreach ( $conditions['query'] as $condition => $expect ) {
-			$num_conditions++;
-
-			switch ( true ) {
-				case 'is_singular' === $condition && ( is_string( $expect ) || is_array( $expect ) ):
-					$result = $wp_query->is_singular( $expect );
-					break;
-
-				case 'is_page' === $condition && ( is_string( $expect ) || is_array( $expect ) ):
-					$result = $wp_query->is_page( $expect );
-					break;
-
-				case 'is_tax' === $condition && ( is_string( $expect ) || is_array( $expect ) ):
-					$result = $wp_query->is_tax( $expect );
-					break;
-
-				case method_exists( $wp_query, $condition ) && is_callable( [ $wp_query, $condition ] ):
-					$result = call_user_func( [ $wp_query, $condition ] ) === $expect; // @phpstan-ignore-line
-					break;
-
-				default:
-					$result = false;
-					break;
-			}
-
-			if ( false === $result ) {
-				break;
-			}
-
-			$num_true++;
-		}
-	}
-
-	/*
-	 * Checks the index of how many times the parent condition block has been rendered, like:
-	 *
-	 * {"index": {"===": 0}}
-	 * {"index": {">": 2}}
-	 * {"index": {">": 2, "<": 4}}
-	 *
-	 * @see \Alley\Validator\Comparison for the available operators.
-	 *
-	 * Note that this approach means that two identical conditions with two identical set of
-	 * child blocks will use the same counter.
-	 */
-	if ( isset( $conditions['index'] ) ) {
-		$num_conditions++;
-
-		$validator = new \Laminas\Validator\ValidatorChain();
-
-		foreach ( $conditions['index'] as $operator => $compared ) {
-			try {
-				$validator->attach(
-					validator: new \Alley\Validator\Comparison(
-						[
-							'operator' => $operator,
-							'compared' => $compared,
-						],
-					),
-					breakChainOnFailure: true,
-				);
-			} catch ( Exception $exception ) {
-				// Nothing yet.
-				unset( $exception );
-			}
-		}
-
-		if ( count( $validator ) > 0 ) {
-			if ( $validator->isValid( wp_conditional_blocks_current_counter_block() ) ) {
-				$num_true++;
-			}
-		}
-	}
-
+	$wp_block_condition = Conditions::get_instance()->get_condition( $condition_slug );
+	// Validate callable function.
 	if (
-		isset( $conditions['post'] )
-		&& isset( $context['postId'] )
-		&& $context['postId'] > 0
+		empty( $wp_block_condition['callable'] )
+		|| ! is_callable( $wp_block_condition['callable'] )
+		|| ! $wp_query instanceof WP_Query
 	) {
-		$conditions['post'] = (array) $conditions['post'];
-
-		foreach ( $conditions['post'] as $condition ) {
-			$num_conditions++;
-
-			if ( 'has_content' === $condition ) {
-				if ( '' !== get_the_content( null, false, $context['postId'] ) ) {
-					$num_true++;
-				}
-
-				continue;
-			}
-
-			/**
-			 * Filters the condition block's result for the given post condition.
-			 *
-			 * @param bool  $result    Condition result.
-			 * @param mixed $condition Condition name.
-			 * @param int   $post_id   Post ID.
-			 */
-			if ( true === apply_filters( 'wp_conditional_blocks_condition_block_post_condition', false, $condition, $context['postId'] ) ) {
-				$num_true++;
-			}
-		}
+		return false;
 	}
 
-	if ( isset( $conditions['custom'] ) ) {
-		$conditions['custom'] = (array) $conditions['custom'];
+	// Execute conditional's callable.
+	$callable_result = call_user_func( $wp_block_condition['callable'] );
 
-		foreach ( $conditions['custom'] as $condition ) {
-			$num_conditions++;
-		}
-	}
-
-	if ( isset( $conditions['condition'] ) ) {
-		$conditions['condition'] = (array) $conditions['condition'];
-
-		foreach ( $conditions['condition'] as $name ) {
-			$num_conditions++;
-
-			/**
-			 * Filters the condition block's result for the given condition.
-			 *
-			 * @param bool     $result   Condition result.
-			 * @param array    $context  Available context.
-			 * @param WP_Query $wp_query Global query object.
-			 */
-			$result = apply_filters( "wp_conditional_blocks_condition_block_{$name}_condition", false, $context, $wp_query );
-
-			if ( true === $result ) {
-				$num_true++;
-			}
-		}
-	}
-
-	return $num_conditions > 0 && $num_conditions === $num_true;
+	 /**
+	 * Filters the condition block's result for the given condition.
+	 *
+	 * @param bool     $result   Condition result.
+	 * @param array    $context  Available context.
+	 * @param WP_Query $wp_query Global query object.
+	 */
+	return apply_filters( "wp_conditional_blocks_condition_block_{$wp_block_condition['slug']}_condition", $callable_result, $context, $wp_query );
 }

--- a/src/class-conditions.php
+++ b/src/class-conditions.php
@@ -130,6 +130,15 @@ class Conditions {
 	}
 
 	/**
+	 * Initializes the conditions.
+	 *
+	 * @return void
+	 */
+	public function init(): void {
+		add_action( 'init', [ $this, 'add_default_conditions' ] );
+	}
+
+	/**
 	 * Resets the conditions for testing purposes.
 	 *
 	 * @internal
@@ -139,5 +148,17 @@ class Conditions {
 	 */
 	public function reset_conditions_for_testing(): void {
 		$this->conditions = [];
+	}
+
+	/**
+	 * Crates and adds default conditions.
+	 *
+	 * @return void
+	 */
+	public function add_default_conditions(): void {
+		$this->add_condition( 'Is Archive Page', 'is_archive', fn() => is_archive() );
+		$this->add_condition( 'Is Home Page', 'is_home_page', fn() => is_home() || is_front_page() );
+		$this->add_condition( 'Is Search Page', 'is_search', fn() => is_search() );
+		$this->add_condition( 'Is Single', 'is_single', fn() => is_single() );
 	}
 }

--- a/src/class-conditions.php
+++ b/src/class-conditions.php
@@ -151,7 +151,7 @@ class Conditions {
 	}
 
 	/**
-	 * Crates and adds default conditions.
+	 * Creates and adds default conditions.
 	 *
 	 * @return void
 	 */


### PR DESCRIPTION
## Summary

[wp-conditional-blocks] Basic Conditions add basic default conditions

## Notes for reviewers

None.

## Changelog entries

### Added
- a shortlist of "default" conditions
- a select menu in the slotfill sidebar for selecting conditions added via filters.

### Changed
- logic in render function callback to align with new condition attribute.

### Deprecated

### Removed
- logic pertaining to the previous method of adding a condition (including, conditions, query, post, index)
- fields pertaining to the above from the slotfill sidebar

### Fixed

### Security

## Ticket(s)

- [TECH-84](https://alleyinteractive.atlassian.net/browse/TECH-84)


[TECH-84]: https://alleyinteractive.atlassian.net/browse/TECH-84?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ